### PR TITLE
remove update totalEncryptedSupply

### DIFF
--- a/wrapping-ERC20/WrappingERC20.sol
+++ b/wrapping-ERC20/WrappingERC20.sol
@@ -22,7 +22,5 @@ contract ExampleToken is FHERC20 {
             } else {
                 _encBalances[msg.sender] = _encBalances[msg.sender] + amount;
             }
-
-            totalEncryptedSupply = totalEncryptedSupply + amount;
         }        
 }


### PR DESCRIPTION
As `totalEncryptedSupply` is define as a private variable, it cannot be accessed in child contract. I remove it then the example wrapping-ERC20 contract can be compile successfully.